### PR TITLE
Fixing wheelDeltaY issue on chrome

### DIFF
--- a/dist/angular-fontselect.js
+++ b/dist/angular-fontselect.js
@@ -1296,7 +1296,12 @@
           event.preventDefault();
           event.stopPropagation();
 
-          var originalEvent = event.originalEvent;
+          var originalEvent;
+          if(event.type === 'wheel')
+            originalEvent = event;
+          else
+            originalEvent = event.originalEvent;
+
           var subpage = 1 / page.size;
           var delta = originalEvent.wheelDeltaY || originalEvent.wheelDelta ||
             originalEvent.deltaY * -1 || originalEvent.detail * -1;


### PR DESCRIPTION
On chrome thsis error appears

Uncaught TypeError: Cannot read property 'wheelDeltaY' of undefinedangular-fontselect.js:1302 fontselectModule.controller.wheelHandlerangular.js:3011 eventHandler

![screenshot 2015-03-11 23 45 47](https://cloud.githubusercontent.com/assets/1566934/6611216/c77a9d6a-c848-11e4-8b0e-c3e156cbf5e3.png)

By asking the type of event, it is possible to bypass the error.
